### PR TITLE
Update ServiceNowCICDRestAPIService.js

### DIFF
--- a/src/lib/ServiceNowCICDRestAPIService.js
+++ b/src/lib/ServiceNowCICDRestAPIService.js
@@ -23,7 +23,10 @@ function ServiceNowCICDRestAPIService(instance, auth, transport = null) {
     ) {
         throw new Error('Incorrect auth');
     }
+   instance = instance.replace(/(^\https:|^)\/\//, '').replace(/^\/|\/$/g, '');
+    /* Replaced the regular expression so that if the instance URL contains extra parameters those can be used.
     instance = instance.replace(/(?:^https?:\/\/)?([^\/]+)(?:\/.*$)/, '$1');
+    */
     if (!instance.length) {
         throw new Error('Incorrect instance');
     }


### PR DESCRIPTION
Added line 26 (Regular expression that removes https from instance URL and keeps the extra parameters )

If the URL is https://servicenow-cicd-proxy.azure-api.net/ing then the output of line 26 in the code (before this pull request ) will give output as 'servicenow-cicd-proxy.azure-api.net' but in our case we need the ouput as 'servicenow-cicd-proxy.azure-api.net/ing'.

So, I have added a new line of code in the PR so that it works in both the ways.

example : 
1.)	instance= "https://servicenow-cicd-proxy.azure-api.net/ing";
instance = instance.replace(/(^\https:|^)\/\//, '').replace(/^\/|\/$/g, '');
console.log(instance);

output : servicenow-cicd-proxy.azure-api.net/ing

2.)	instance= "https://servicenow-cicd-proxy.azure-api.net/";
instance = instance.replace(/(^\https:|^)\/\//, '').replace(/^\/|\/$/g, '');
console.log(instance);

output : servicenow-cicd-proxy.azure-api.net

If you need more clarity on this thing we can have a call and disucss further but we really wish this will be added to the upcoming release